### PR TITLE
Add sphinx github pages ext

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,7 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
+    "sphinx.ext.githubpages",
 ]
 
 templates_path = ['_templates']


### PR DESCRIPTION
This will disable the use of jekyll when building docs ensuring they render correctly