### PR TITLE
Relax versioningit build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "setuptools >= 61.2",
-    "wheel >= 0.29.0",
-    "versioningit ~= 2.0.1",
+    "versioningit >= 2.0.1",
 ]
 build-backend = 'setuptools.build_meta'
 


### PR DESCRIPTION
Now that versioningit 2.2.0 is released, would it be possible to relax the dependency so that we can build using it? I don't see anything scary in [the release notes](https://github.com/jwodder/versioningit/releases).

I have also removed wheel, per [setuptools documentation](https://setuptools.pypa.io/en/latest/userguide/quickstart.html#basic-use):

> Historically this documentation has unnecessarily listed wheel in the requires list, and many projects still do that. This is not recommended. The backend automatically adds wheel dependency when it is required, and listing it explicitly causes it to be unnecessarily required for source distribution builds. You should only include wheel in requires if you need to explicitly access it during build time (e.g. if your project needs a setup.py script that imports wheel).