### PR TITLE
Drop Python 3.11, set minimum to 3.12

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -21,10 +21,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.12", "3.13", "3.14"]
         exclude:
-          - os: windows-latest
-            python-version: 3.11
           - os: windows-latest
             python-version: 3.13
           - os: windows-latest
@@ -32,7 +30,7 @@ jobs:
     env:
       DISPLAY: ':99.0'
       OS: ${{ matrix.os }}
-      UPLOAD_TO_GHPAGES: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      UPLOAD_TO_GHPAGES: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       SPHINX_WARNINGS_AS_ERROR: 'true'
       SPHINX_OPTS: "-v"
     steps:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -21,10 +21,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.12", "3.13", "3.14"]
         exclude:
-          - os: windows-latest
-            python-version: "3.11"
           - os: windows-latest
             python-version: "3.13"
           - os: windows-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,14 +14,13 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering",
 ]
 license = {text = "MIT"}
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = [
     "qcodes>=0.42.0",
     "h5py>=3.0.0",


### PR DESCRIPTION
- \equires-python\: \>=3.11\ → \>=3.12\
- Remove Python 3.11 classifier (keep 3.12, 3.13, 3.14)
- Remove 3.11 from CI matrix in pytest.yaml and docs.yaml
- Update docs GH Pages deploy to use Python 3.12

Part of the Python 3.12 minimum version migration across the measurement code stack.